### PR TITLE
Bugfixes/update gazebo related

### DIFF
--- a/melfa_bringup/launch/rh6crh6020_control.launch.py
+++ b/melfa_bringup/launch/rh6crh6020_control.launch.py
@@ -318,7 +318,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": ["-r", "-v", "4", "empty.sdf"]}.items(),
+        launch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_bringup/launch/rh6frh5520_control.launch.py
+++ b/melfa_bringup/launch/rh6frh5520_control.launch.py
@@ -329,7 +329,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": ["-r", "-v", "4", "empty.sdf"]}.items(),
+        launch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_bringup/launch/rv13frl_control.launch.py
+++ b/melfa_bringup/launch/rv13frl_control.launch.py
@@ -329,7 +329,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": ["-r", "-v", "4", "empty.sdf"]}.items(),
+        launch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_bringup/launch/rv2fr_control.launch.py
+++ b/melfa_bringup/launch/rv2fr_control.launch.py
@@ -329,7 +329,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": ["-r", "-v", "4", "empty.sdf"]}.items(),
+        launch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_bringup/launch/rv4fr_control.launch.py
+++ b/melfa_bringup/launch/rv4fr_control.launch.py
@@ -329,7 +329,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": ["-r", "-v", "4", "empty.sdf"]}.items(),
+        launch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_bringup/launch/rv4frl_control.launch.py
+++ b/melfa_bringup/launch/rv4frl_control.launch.py
@@ -329,7 +329,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": ["-r", "-v", "4", "empty.sdf"]}.items(),
+        launch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_bringup/launch/rv5as_control.launch.py
+++ b/melfa_bringup/launch/rv5as_control.launch.py
@@ -318,7 +318,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": ["-r", "-v", "4", "empty.sdf"]}.items(),
+        launch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_bringup/launch/rv7frl_control.launch.py
+++ b/melfa_bringup/launch/rv7frl_control.launch.py
@@ -329,7 +329,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": ["-r", "-v", "4", "empty.sdf"]}.items(),
+        launch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_bringup/launch/rv80fr_control.launch.py
+++ b/melfa_bringup/launch/rv80fr_control.launch.py
@@ -329,7 +329,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": ["-r", "-v", "4", "empty.sdf"]}.items(),
+        launch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_bringup/launch/rv8crl_control.launch.py
+++ b/melfa_bringup/launch/rv8crl_control.launch.py
@@ -318,7 +318,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": ["-r", "-v", "4", "empty.sdf"]}.items(),
+        llaunch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_bringup/launch/rv8crl_control.launch.py
+++ b/melfa_bringup/launch/rv8crl_control.launch.py
@@ -318,7 +318,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        llaunch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
+        launch_arguments={"gz_args":"-r-v 4 empty.sdf"}.items(),
         condition=IfCondition(use_sim),
     )
     # Make topics available in ROS2

--- a/melfa_description/ros2_control/rh6crh6020.hardware.xacro
+++ b/melfa_description/ros2_control/rh6crh6020.hardware.xacro
@@ -95,7 +95,7 @@
                 <state_interface name="position"/>
                 <xacro:if value="$(arg use_sim)">
                     <state_interface name="position">
-                        <param name="initial_value">${initial_positions['rv_joint_4']}</param>
+                        <param name="initial_value">${initial_positions['rh_joint_4']}</param>
                     </state_interface>
                 </xacro:if>
             </joint>

--- a/melfa_driver/src/hardware_interface.cpp
+++ b/melfa_driver/src/hardware_interface.cpp
@@ -583,9 +583,6 @@ hardware_interface::return_type MELFAPositionHardwareInterface::read(const rclcp
     {
       joint_position_states_[6] = api_wrap_->fb_pack.jnt_EFB.j7;
     }
-    RCLCPP_WARN(rclcpp::get_logger("MELFAPositionHardwareInterface"), "WARN: Packet lost. %d",
-                api_wrap_->packet_recv_lost);
-    return hardware_interface::return_type::OK;
   }
 
   if (is_j8 == 1)

--- a/melfa_moveit_config/melfa_rh6crh6020_moveit_config/package.xml
+++ b/melfa_moveit_config/melfa_rh6crh6020_moveit_config/package.xml
@@ -28,7 +28,7 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>melfa_description</exec_depend>


### PR DESCRIPTION
## Summary 
Fixed Gazebo and Additional Axis related bugs. 

## Gazebo

Environment not loading properly

In all robot bringup launch files, string concatenation in the world parameter was malfunctioning.

This prevented Gazebo from loading lighting and the ground plane correctly.

- Fixed by correcting path concatenation logic in launch files.

rh6crh6020 launch failure

Gazebo failed to start due to a misnamed joint in the corresponding hardware.xacro file.

- Updated the joint name to match the URDF and YAML configuration.

## Additional Axis

In hardware_interface.cpp, removed an unnecessary early return inside the J7 handling block (lines 586 – 588).

This prevented proper initialization and control of the 7th axis during startup.

✅ Verified correct behavior after fix.
## Test Result
Gazebo launch (all models)	✅ Environment and lighting load correctly
RH6CRH6020 simulation	✅ Launch successful, no xacro errors
Additional axis motion (fake hardware)	✅ Functions as expected
Build on ROS 2 Humble (Ubuntu 22.04)	✅ Passed
